### PR TITLE
Handle platform independent newline characters in 'grade' file

### DIFF
--- a/src/main/java/io/breen/socrates/TextGradeReportFormatter.java
+++ b/src/main/java/io/breen/socrates/TextGradeReportFormatter.java
@@ -166,13 +166,15 @@ public class TextGradeReportFormatter extends GradeReportFormatter {
         w.close();
     }
 
+    private final static String nl = System.getProperty("line.separator");
+
     private void line(Writer writer) throws IOException {
-        writer.append(System.getProperty("line.separator"));
+        writer.append(nl);
     }
 
     private void insertNotes(StringBuilder builder, String notes) {
-        String nl = System.getProperty("line.separator");
         builder.append(nl + nl + "\tGrader notes: ");
+        builder.append(notes);
         builder.append(nl);
     }
 

--- a/src/main/java/io/breen/socrates/TextGradeReportFormatter.java
+++ b/src/main/java/io/breen/socrates/TextGradeReportFormatter.java
@@ -172,9 +172,7 @@ public class TextGradeReportFormatter extends GradeReportFormatter {
 
     private void insertNotes(StringBuilder builder, String notes) {
         String nl = System.getProperty("line.separator");
-        builder.append(nl);
-        builder.append(nl);
-        builder.append("\tGrader notes: ");
+        builder.append(nl + nl + "\tGrader notes: ");
         builder.append(nl);
     }
 

--- a/src/main/java/io/breen/socrates/TextGradeReportFormatter.java
+++ b/src/main/java/io/breen/socrates/TextGradeReportFormatter.java
@@ -137,9 +137,7 @@ public class TextGradeReportFormatter extends GradeReportFormatter {
                 }
 
                 if (!d.notes.isEmpty()) {
-                    builder.append("\n\n\tGrader notes: ");
-                    builder.append(d.notes);
-                    builder.append("\n");
+                    insertNotes(builder, d.notes);
                 }
 
                 w.append(builder.toString());
@@ -169,7 +167,15 @@ public class TextGradeReportFormatter extends GradeReportFormatter {
     }
 
     private void line(Writer writer) throws IOException {
-        writer.append("\n");
+        writer.append(System.getProperty("line.separator"));
+    }
+
+    private void insertNotes(StringBuilder builder, String notes) {
+        String nl = System.getProperty("line.separator");
+        builder.append(nl);
+        builder.append(nl);
+        builder.append("\tGrader notes: ");
+        builder.append(nl);
     }
 
     private List<Deduction> getDeductions(TestGroupWrapperNode root) {
@@ -223,9 +229,7 @@ public class TextGradeReportFormatter extends GradeReportFormatter {
             builder.append(description);
 
             if (!notes.isEmpty()) {
-                builder.append("\n\n\tGrader notes: ");
-                builder.append(notes);
-                builder.append("\n");
+                insertNotes(builder, notes);
             }
 
             return builder.toString();


### PR DESCRIPTION
This addresses something I've noticed previously as a Windows user - many Windows editors would not display newlines correctly in the grade file, which made manual edits a bit difficult without moving to a more sophisticated editor. Fetching the line separator property over appending '\n' should fix the CRLF endings independently.

If it is the case that grade files must have a particular return character when sent back up, this can be disregarded.
